### PR TITLE
Implement LimitedConcurrencyLoadProfileWithDelay

### DIFF
--- a/src/QueryPressure.Core/LoadProfiles/LimitedConcurrencyLoadProfile.cs
+++ b/src/QueryPressure.Core/LoadProfiles/LimitedConcurrencyLoadProfile.cs
@@ -1,34 +1,29 @@
-﻿using System.Collections.Concurrent;
-using QueryPressure.Core.Interfaces;
+﻿using QueryPressure.Core.Interfaces;
 
 namespace QueryPressure.Core.LoadProfiles;
 
-// public class LimitedConcurrencyLoadProfileWithDelay : IProfile
-// {
-//     private readonly TimeSpan _delay;
-//     private readonly IProfile _internal;
-//     private readonly ConcurrentDictionary<Guid, DateTime> _dateTimes = new();
-//
-//     public LimitedConcurrencyLoadProfileWithDelay(int limit, TimeSpan delay)
-//     {
-//         _delay = delay;
-//         _internal = new LimitedConcurrencyLoadProfile(limit);
-//         _delays = new List<Task>(limit);
-//     }
-//     
-//     public async Task<bool> WhenNextCanBeExecutedAsync(CancellationToken cancellationToken)
-//     {
-//         await _internal.WhenNextCanBeExecutedAsync(cancellationToken);
-//         bool shouldWait = _semaphore.CurrentCount >= _limit;
-//         _delays.Remove(await Task.WhenAny(_delays));
-//     }
-//
-//     public Task OnQueryExecutedAsync(CancellationToken cancellationToken)
-//     {
-//         _delays.Add(Task.Delay(delay, cancellationToken));
-//         _internal.OnQueryExecutedAsync(cancellationToken);
-//     }
-// }
+public class LimitedConcurrencyLoadProfileWithDelay : IProfile
+{
+    private readonly TimeSpan _delay;
+    private readonly IProfile _internal;
+
+    public LimitedConcurrencyLoadProfileWithDelay(int limit, TimeSpan delay)
+    {
+        _delay = delay;
+        _internal = new LimitedConcurrencyLoadProfile(limit);
+    }
+
+    public Task<bool> WhenNextCanBeExecutedAsync(CancellationToken cancellationToken)
+    {
+        return _internal.WhenNextCanBeExecutedAsync(cancellationToken);
+    }
+
+    public async Task OnQueryExecutedAsync(CancellationToken cancellationToken)
+    {
+        await Task.Delay(_delay, cancellationToken);
+        await _internal.OnQueryExecutedAsync(cancellationToken);
+    }
+}
 
 public class LimitedConcurrencyLoadProfile : IProfile
 {

--- a/src/QueryPressure.Tests/LimitedConcurrencyLoadProfileWithDelayTests.cs
+++ b/src/QueryPressure.Tests/LimitedConcurrencyLoadProfileWithDelayTests.cs
@@ -1,0 +1,82 @@
+﻿using QueryPressure.Core.LoadProfiles;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace QueryPressure.Tests;
+
+public class LimitedConcurrencyLoadProfileWithDelayTests
+{
+    [Fact]
+    public async Task WhenNextCanBeExecutedAsync_TheNextAfterLimitExceededTaskCompleted_After_OnQueryExecutedAsync_Called()
+    {
+        TimeSpan delay = TimeSpan.FromMilliseconds(500);
+
+        var profile = new LimitedConcurrencyLoadProfileWithDelay(2, delay);
+        _ = profile.WhenNextCanBeExecutedAsync(CancellationToken.None);
+        _ = profile.WhenNextCanBeExecutedAsync(CancellationToken.None);
+
+        var tasks = new[] {
+            profile.WhenNextCanBeExecutedAsync(CancellationToken.None),
+            profile.WhenNextCanBeExecutedAsync(CancellationToken.None)
+        };
+
+        await Task.Delay(15);
+        Assert.All(tasks, t => Assert.False(t.IsCompleted));
+
+        _ = profile.OnQueryExecutedAsync(CancellationToken.None);
+        _ = profile.OnQueryExecutedAsync(CancellationToken.None);
+        Assert.All(tasks, t => Assert.False(t.IsCompleted));
+
+        await Task.Delay(1.5 * delay);
+        Assert.All(tasks, t => Assert.True(t.IsCompletedSuccessfully));
+    }
+
+    [Fact]
+    public async Task WhenNextCanBeExecutedAsync_DelayTasksFinished_AfterCallWhenNextCanBeExecutedAsync()
+    {
+        TimeSpan delay = TimeSpan.FromMilliseconds(500);
+
+        var profile = new LimitedConcurrencyLoadProfileWithDelay(2, delay);
+        _ = profile.WhenNextCanBeExecutedAsync(CancellationToken.None);
+        _ = profile.WhenNextCanBeExecutedAsync(CancellationToken.None);
+
+        var tasks = new[] {
+            profile.WhenNextCanBeExecutedAsync(CancellationToken.None),
+            profile.WhenNextCanBeExecutedAsync(CancellationToken.None),
+        };
+
+        await Task.Delay(15);
+        Assert.All(tasks, t => Assert.False(t.IsCompleted));
+
+        int startTimestamp = Environment.TickCount;
+
+        _ = profile.OnQueryExecutedAsync(CancellationToken.None);
+        _ = profile.OnQueryExecutedAsync(CancellationToken.None);
+
+        await Task.WhenAll(tasks);
+
+        int elapsedMiliseconds = Environment.TickCount - startTimestamp;
+
+        Assert.InRange(elapsedMiliseconds,
+            low: delay.TotalMilliseconds,
+            high: delay.TotalMilliseconds * 2);
+    }
+
+    [Fact]
+    public void WhenNextCanBeExecutedAsync_DelayTasksNotFinished_WithoutCallWhenNextCanBeExecutedAsync()
+    {
+        TimeSpan delay = TimeSpan.FromMilliseconds(250);
+
+        var profile = new LimitedConcurrencyLoadProfileWithDelay(2, delay);
+        _ = profile.WhenNextCanBeExecutedAsync(CancellationToken.None);
+        _ = profile.WhenNextCanBeExecutedAsync(CancellationToken.None);
+
+        var task = profile.WhenNextCanBeExecutedAsync(CancellationToken.None);
+        Assert.False(task.Wait(delay * 4));
+
+        _ = profile.OnQueryExecutedAsync(CancellationToken.None);
+        Assert.True(task.Wait(delay * 2));
+    }
+}


### PR DESCRIPTION
Since the "OnQueryExecutedAsync" method does not block the main "QueryExecutor" loop, we can just add a wait before calling the original method of the "LimitedConcurrencyLoadProfile" class