### PR TITLE
Restore MySql plugin

### DIFF
--- a/src/QueryPressure.MySql.App/MySqlConnectionProviderCreator.cs
+++ b/src/QueryPressure.MySql.App/MySqlConnectionProviderCreator.cs
@@ -7,13 +7,13 @@ using QueryPressure.MySql.Core;
 [assembly: QueryPressurePlugin]
 namespace QueryPressure.MySql.App
 {
-    public class MySqlConnectionProviderCreator : ICreator<IConnectionProvider>
+  public class MySqlConnectionProviderCreator : ICreator<IConnectionProvider>
+  {
+    public string Type => "mysql";
+    public IConnectionProvider Create(ArgumentsSection argumentsSection)
     {
-        public string Type => "mysql";
-        public IConnectionProvider Create(ArgumentsSection argumentsSection)
-        {
-            var connectionString = argumentsSection.ExtractStringArgumentOrThrow("connectionString");
-            return new MySqlConnectionProvider(connectionString);
-        }
+      var connectionString = argumentsSection.ExtractStringArgumentOrThrow("connectionString");
+      return new MySqlConnectionProvider(connectionString);
     }
+  }
 }

--- a/src/QueryPressure.MySql.App/MySqlConnectionProviderCreator.cs
+++ b/src/QueryPressure.MySql.App/MySqlConnectionProviderCreator.cs
@@ -1,0 +1,19 @@
+using QueryPressure.Core;
+using QueryPressure.App.Arguments;
+using QueryPressure.App.Interfaces;
+using QueryPressure.Core.Interfaces;
+using QueryPressure.MySql.Core;
+
+[assembly: QueryPressurePlugin]
+namespace QueryPressure.MySql.App
+{
+    public class MySqlConnectionProviderCreator : ICreator<IConnectionProvider>
+    {
+        public string Type => "mysql";
+        public IConnectionProvider Create(ArgumentsSection argumentsSection)
+        {
+            var connectionString = argumentsSection.ExtractStringArgumentOrThrow("connectionString");
+            return new MySqlConnectionProvider(connectionString);
+        }
+    }
+}

--- a/src/QueryPressure.MySql.App/QueryPressure.MySql.App.csproj
+++ b/src/QueryPressure.MySql.App/QueryPressure.MySql.App.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Autofac" Version="6.4.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\QueryPressure.App\QueryPressure.App.csproj" />
+      <ProjectReference Include="..\QueryPressure.MySql.Core\QueryPressure.MySql.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/QueryPressure.MySql.Core/MySqlConnectionProvider.cs
+++ b/src/QueryPressure.MySql.Core/MySqlConnectionProvider.cs
@@ -3,16 +3,19 @@ using QueryPressure.Core;
 
 namespace QueryPressure.MySql.Core
 {
-    public class MySqlConnectionProvider: ConnectionProviderBase<MySqlConnection>
+  public class MySqlConnectionProvider : ConnectionProviderBase<MySqlConnection>
+  {
+    public MySqlConnectionProvider(string connectionString) : base(connectionString)
     {
-        public MySqlConnectionProvider(string connectionString) : base(connectionString)
-        { }
-
-        protected override async Task<MySqlConnection> CreateOpenConnectionAsync(string connectionString, CancellationToken cancellationToken)
-        {
-            var connection = new MySqlConnection(connectionString);
-            await connection.OpenAsync(cancellationToken);
-            return connection;
-        }
     }
+
+    protected override async Task<MySqlConnection> CreateOpenConnectionAsync(
+      string connectionString,
+      CancellationToken cancellationToken)
+    {
+      var connection = new MySqlConnection(connectionString);
+      await connection.OpenAsync(cancellationToken);
+      return connection;
+    }
+  }
 }

--- a/src/QueryPressure.MySql.Core/MySqlConnectionProvider.cs
+++ b/src/QueryPressure.MySql.Core/MySqlConnectionProvider.cs
@@ -1,0 +1,18 @@
+using MySqlConnector;
+using QueryPressure.Core;
+
+namespace QueryPressure.MySql.Core
+{
+    public class MySqlConnectionProvider: ConnectionProviderBase<MySqlConnection>
+    {
+        public MySqlConnectionProvider(string connectionString) : base(connectionString)
+        { }
+
+        protected override async Task<MySqlConnection> CreateOpenConnectionAsync(string connectionString, CancellationToken cancellationToken)
+        {
+            var connection = new MySqlConnection(connectionString);
+            await connection.OpenAsync(cancellationToken);
+            return connection;
+        }
+    }
+}

--- a/src/QueryPressure.MySql.Core/QueryPressure.MySql.Core.csproj
+++ b/src/QueryPressure.MySql.Core/QueryPressure.MySql.Core.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\QueryPressure.Core\QueryPressure.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="MySqlConnector" Version="2.2.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/QueryPressure/docker-compse.mysql.yml
+++ b/src/QueryPressure/docker-compse.mysql.yml
@@ -10,6 +10,7 @@ services:
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes
+      - MYSQL_DATABASE=query_pressure_db
     healthcheck:
       test: ['CMD', '/opt/bitnami/scripts/mysql/healthcheck.sh']
       interval: 15s

--- a/src/QueryPressure/sample.mysql.yml
+++ b/src/QueryPressure/sample.mysql.yml
@@ -9,4 +9,4 @@ limit:
 connection:
   type: mysql
   arguments:
-    connectionString: Host=localhost;Database=information_schema;User Id=root;
+    connectionString: Host=localhost;Database=query_pressure_db;User Id=root;SSL Mode=None


### PR DESCRIPTION
MySql plugin got lost and did not get into the repository. Because of this, the project did not build. 

- Restored the plugin. 
- Replaced the connector, because MySqlClient does not work. 
- Fixed sample.