### PR TITLE
Reduced "dotnet" command description in the workflow file.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
 
+    env:
+      Scripts: ./.github/workflows/scripts
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -24,13 +27,11 @@ jobs:
         cp -r frontend/dist/* src/QueryPressure.UI/dist/
 
     - name: Build and publish dotnet app
+      shell: pwsh
       run: |
-        dotnet publish src/QueryPressure.UI/QueryPressure.UI.csproj -c Release --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false -p:IncludeNativeLibrariesForSelfExtract=true \
-          --output src/QueryPressure.UI/.out/win --runtime win-x64
-        dotnet publish src/QueryPressure.UI/QueryPressure.UI.csproj -c Release --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false -p:IncludeNativeLibrariesForSelfExtract=true \
-          --output src/QueryPressure.UI/.out/linux --runtime linux-x64
-        dotnet publish src/QueryPressure.UI/QueryPressure.UI.csproj -c Release --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false -p:IncludeNativeLibrariesForSelfExtract=true \
-          --output src/QueryPressure.UI/.out/osx --runtime osx-x64
+        ${{ env.Scripts }}/DotnetPublish.ps1 -OutputSubfolder win -Runtime win-x64
+        ${{ env.Scripts }}/DotnetPublish.ps1 -OutputSubfolder linux -Runtime linux-x64
+        ${{ env.Scripts }}/DotnetPublish.ps1 -OutputSubfolder osx -Runtime osx-x64
         
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/scripts/DotnetPublish.ps1
+++ b/.github/workflows/scripts/DotnetPublish.ps1
@@ -1,0 +1,20 @@
+param (
+  [string] $OutputSubfolder,
+  [string] $Runtime
+)
+
+dotnet publish src/QueryPressure.UI/QueryPressure.UI.csproj `
+  -c Release `
+  --self-contained true `
+  -p:PublishSingleFile=true `
+  -p:PublishReadyToRun=true `
+  -p:PublishTrimmed=true `
+  -p:DebugType=None `
+  -p:DebugSymbols=false `
+  -p:IncludeNativeLibrariesForSelfExtract=true `
+  --output src/QueryPressure.UI/.out/$OutputSubfolder `
+  --runtime $Runtime
+
+if ($LastExitCode -ne 0) {
+  throw
+}


### PR DESCRIPTION
I saw your stream on YouTube and notice you are not happy with duplications of the `dotnet publish` command in the workflow file. So, let me share the approach I use in such cases for my projects.