### PR TITLE
Create Vite config to use Azure backend for development

### DIFF
--- a/frontend/azure-vite.config.ts
+++ b/frontend/azure-vite.config.ts
@@ -1,0 +1,37 @@
+import react from '@vitejs/plugin-react';
+import * as path from 'path';
+import {defineConfig} from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://querypressure-dev.azurewebsites.net',
+        changeOrigin: true,
+        secure: true
+      },
+      '/ws': {
+        target: 'ws://querypressure-dev.azurewebsites.net',
+        changeOrigin: true,
+        secure: true
+      }
+    },
+    port: 5173
+  },
+  resolve: {
+    alias: [
+      {find: '@', replacement: path.resolve(__dirname, 'src')},
+      {find: '@components', replacement: path.resolve(__dirname, 'src', 'components')},
+      {find: '@utils', replacement: path.resolve(__dirname, 'src', 'utils')},
+      {find: '@assets', replacement: path.resolve(__dirname, 'src', 'assets')},
+      {find: '@models', replacement: path.resolve(__dirname, 'src', 'models')},
+      {find: '@api', replacement: path.resolve(__dirname, 'src', 'api')},
+      {find: '@services', replacement: path.resolve(__dirname, 'src', 'services')},
+      {find: '@containers', replacement: path.resolve(__dirname, 'src', 'containers')},
+      {find: '@hooks', replacement: path.resolve(__dirname, 'src', 'hooks')},
+      {find: '~bootstrap', replacement: path.resolve(__dirname, 'node_modules/bootstrap')}
+    ]
+  }
+});

--- a/frontend/azure-vite.config.ts
+++ b/frontend/azure-vite.config.ts
@@ -1,10 +1,9 @@
-import react from '@vitejs/plugin-react';
-import * as path from 'path';
 import {defineConfig} from 'vite';
 
-// https://vitejs.dev/config/
+import {baseConfig} from './vite.config';
+
 export default defineConfig({
-  plugins: [react()],
+  ...baseConfig,
   server: {
     proxy: {
       '/api': {
@@ -17,21 +16,6 @@ export default defineConfig({
         changeOrigin: true,
         secure: true
       }
-    },
-    port: 5173
+    }
   },
-  resolve: {
-    alias: [
-      {find: '@', replacement: path.resolve(__dirname, 'src')},
-      {find: '@components', replacement: path.resolve(__dirname, 'src', 'components')},
-      {find: '@utils', replacement: path.resolve(__dirname, 'src', 'utils')},
-      {find: '@assets', replacement: path.resolve(__dirname, 'src', 'assets')},
-      {find: '@models', replacement: path.resolve(__dirname, 'src', 'models')},
-      {find: '@api', replacement: path.resolve(__dirname, 'src', 'api')},
-      {find: '@services', replacement: path.resolve(__dirname, 'src', 'services')},
-      {find: '@containers', replacement: path.resolve(__dirname, 'src', 'containers')},
-      {find: '@hooks', replacement: path.resolve(__dirname, 'src', 'hooks')},
-      {find: '~bootstrap', replacement: path.resolve(__dirname, 'node_modules/bootstrap')}
-    ]
-  }
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "azure": "vite --config azure-vite.config.js",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint ./src --ext .jsx,.js,.ts,.tsx --ignore-path ./.gitignore",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,22 +2,9 @@ import react from '@vitejs/plugin-react';
 import * as path from 'path';
 import {defineConfig} from 'vite';
 
-// https://vitejs.dev/config/
-export default defineConfig({
+export const baseConfig = {
   plugins: [react()],
   server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:5073',
-        changeOrigin: true,
-        secure: false
-      },
-      '/ws': {
-        target: 'ws://localhost:5073',
-        changeOrigin: true,
-        secure: false
-      },
-    },
     port: 5173
   },
   resolve: {
@@ -33,5 +20,24 @@ export default defineConfig({
       {find: '@hooks', replacement: path.resolve(__dirname, 'src', 'hooks')},
       {find: '~bootstrap', replacement: path.resolve(__dirname, 'node_modules/bootstrap')}
     ]
+  },
+};
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  ...baseConfig,
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5073',
+        changeOrigin: true,
+        secure: false
+      },
+      '/ws': {
+        target: 'ws://localhost:5073',
+        changeOrigin: true,
+        secure: false
+      },
+    }
   }
 });


### PR DESCRIPTION
For the convenience of UI developers, I added a config that does not need to run the backend locally but can use the public backend deployed on Azure.

`npm run azure`