### PR TITLE
feat: added provider syntax highlighting

### DIFF
--- a/frontend/src/api/ProvidersApi.ts
+++ b/frontend/src/api/ProvidersApi.ts
@@ -1,5 +1,7 @@
+import {ProviderModel} from '@models';
+
 export const ProvidersApi = {
-  getAll(): Promise<string[]> {
+  getAll(): Promise<ProviderModel[]> {
     return fetch('/api/providers')
       .then(r => r.json());
   }

--- a/frontend/src/containers/EditorCard/EditorCard.models.ts
+++ b/frontend/src/containers/EditorCard/EditorCard.models.ts
@@ -1,7 +1,10 @@
+import { ProviderModel } from "@/models";
+
 export interface EditorCardProps {
   providers: string[];
   executionId: string;
   selectedProvider: string | null;
+  selectedProviderInfo: ProviderModel | null;
   selectProvider: (provider: string) => void;
   setScript: (script: string) => void;
   theme: string;

--- a/frontend/src/containers/Layout/Layout.tsx
+++ b/frontend/src/containers/Layout/Layout.tsx
@@ -4,7 +4,7 @@ import {useProvider, useToggle} from '@hooks';
 import {useTheme} from '@hooks/useTheme';
 
 export function Layout() {
-  const {providers, selectedProvider, selectProvider} = useProvider();
+  const {providers, selectedProvider, selectedProviderInfo, selectProvider} = useProvider();
   const [script, setScript] = useState('');
   const [executionId, setExecutionId] = useState('');
   const {theme, toggleTheme} = useTheme();
@@ -30,6 +30,7 @@ export function Layout() {
         <EditorCard providers={providers}
                     executionId={executionId}
                     selectedProvider={selectedProvider}
+                    selectedProviderInfo={selectedProviderInfo}
                     selectProvider={selectProvider}
                     setScript={setScript}
                     theme={theme}

--- a/frontend/src/hooks/useProvider.ts
+++ b/frontend/src/hooks/useProvider.ts
@@ -1,33 +1,44 @@
 import {useEffect, useState} from 'react';
 import {ProvidersApi} from '@api';
 import {ProviderService} from '@services';
+import { ProviderModel } from '@/models';
 
 export function useProvider() {
+  const [providerMap, setProviderMap] = useState<Map<string, ProviderModel> | null>(null);
+  const [selectedProviderInfo, setSelectedProviderInfo] = useState<ProviderModel | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const [providers, setProviders] = useState<string[]>([]);
 
   function selectProvider(provider: string) {
     setSelectedProvider(provider);
+    setSelectedProviderInfo(providerMap?.get(provider) ?? null);
     ProviderService.saveCurrent(provider);
   }
 
   function loadProviders(): void {
     ProvidersApi
       .getAll()
-      .then(providers => setProviders(providers));
-
-    const currentProvider = ProviderService.getCurrent();
-    setSelectedProvider(currentProvider);
+      .then(providers => {
+        const providerMap = new Map(providers.map(x => [x.name, x]));
+        const currentProvider = ProviderService.getCurrent();
+        setProviderMap(providerMap);
+        setSelectedProvider(currentProvider);
+        currentProvider && setSelectedProviderInfo(providerMap.get(currentProvider) ?? null);
+      });
   }
-
 
   useEffect(() => {
     loadProviders();
   }, []);
 
+  useEffect(() => {
+    providerMap && setProviders([...providerMap.keys()]);
+  }, [providerMap]);
+
   return {
     providers,
     selectedProvider,
+    selectedProviderInfo,
     selectProvider
   };
 }

--- a/frontend/src/models/ProviderModel.ts
+++ b/frontend/src/models/ProviderModel.ts
@@ -1,0 +1,5 @@
+export interface ProviderModel {
+  name: string;
+  syntaxAliases: string[];
+  initialScript?: string;
+}

--- a/frontend/src/models/index.ts
+++ b/frontend/src/models/index.ts
@@ -1,5 +1,6 @@
 export * from './ArgumentSection';
 export * from './LimitModel';
 export * from './ProfileModel';
+export * from './ProviderModel';
 export * from './ResourceModel';
 export * from './ValidationMessage';

--- a/src/QueryPressure.Core/Interfaces/IProviderInfo.cs
+++ b/src/QueryPressure.Core/Interfaces/IProviderInfo.cs
@@ -3,4 +3,6 @@ namespace QueryPressure.Core.Interfaces;
 public interface IProviderInfo
 {
   string Name { get; }
+  string[] SyntaxAliases { get; }
+  string? InitialScript { get; }
 }

--- a/src/QueryPressure.Core/ProviderInfo.cs
+++ b/src/QueryPressure.Core/ProviderInfo.cs
@@ -2,4 +2,4 @@ using QueryPressure.Core.Interfaces;
 
 namespace QueryPressure.Core;
 
-public record ProviderInfo(string Name) : IProviderInfo;
+public record ProviderInfo(string Name, string[] SyntaxAliases, string? InitialScript = null) : IProviderInfo;

--- a/src/QueryPressure.MongoDB.App/MongoDBAppModule.cs
+++ b/src/QueryPressure.MongoDB.App/MongoDBAppModule.cs
@@ -1,5 +1,4 @@
 using Autofac;
-using QueryPressure.Core;
 using QueryPressure.Core.Interfaces;
 
 namespace QueryPressure.MongoDB.App;
@@ -11,7 +10,7 @@ public class MongoDBAppModule : Module
     builder.RegisterType<MongoDBConnectionProviderCreator>()
         .AsImplementedInterfaces();
 
-    builder.RegisterInstance(new ProviderInfo("MongoDB"))
+    builder.RegisterInstance(new MongoProviderInfo())
       .As<IProviderInfo>();
   }
 }

--- a/src/QueryPressure.MongoDB.App/MongoDBAppModule.cs
+++ b/src/QueryPressure.MongoDB.App/MongoDBAppModule.cs
@@ -10,7 +10,8 @@ public class MongoDBAppModule : Module
     builder.RegisterType<MongoDBConnectionProviderCreator>()
         .AsImplementedInterfaces();
 
-    builder.RegisterInstance(new MongoProviderInfo())
-      .As<IProviderInfo>();
+    builder.RegisterType<MongoProviderInfo>()
+      .As<IProviderInfo>()
+      .SingleInstance();
   }
 }

--- a/src/QueryPressure.MongoDB.App/MongoProviderInfo.cs
+++ b/src/QueryPressure.MongoDB.App/MongoProviderInfo.cs
@@ -1,0 +1,8 @@
+using QueryPressure.Core;
+
+namespace QueryPressure.MongoDB.App;
+
+public record MongoProviderInfo()
+  : ProviderInfo("MongoDB", new[] { "mongo", "javascript" }, "")
+{
+}

--- a/src/QueryPressure.MySql.App/MySqlAppModule.cs
+++ b/src/QueryPressure.MySql.App/MySqlAppModule.cs
@@ -1,5 +1,4 @@
 using Autofac;
-using QueryPressure.Core;
 using QueryPressure.Core.Interfaces;
 
 namespace QueryPressure.MySql.App;
@@ -11,7 +10,7 @@ public class MySqlAppModule : Module
     builder.RegisterType<MySqlConnectionProviderCreator>()
       .AsImplementedInterfaces();
 
-    builder.RegisterInstance(new ProviderInfo("MySql"))
+    builder.RegisterInstance(new MySqlProviderInfo())
       .As<IProviderInfo>();
   }
 }

--- a/src/QueryPressure.MySql.App/MySqlAppModule.cs
+++ b/src/QueryPressure.MySql.App/MySqlAppModule.cs
@@ -10,7 +10,8 @@ public class MySqlAppModule : Module
     builder.RegisterType<MySqlConnectionProviderCreator>()
       .AsImplementedInterfaces();
 
-    builder.RegisterInstance(new MySqlProviderInfo())
-      .As<IProviderInfo>();
+    builder.RegisterType<MySqlProviderInfo>()
+      .As<IProviderInfo>()
+      .SingleInstance();
   }
 }

--- a/src/QueryPressure.MySql.App/MySqlProviderInfo.cs
+++ b/src/QueryPressure.MySql.App/MySqlProviderInfo.cs
@@ -1,0 +1,19 @@
+using QueryPressure.Core;
+
+namespace QueryPressure.MySql.App;
+
+public record MySqlProviderInfo() 
+  : ProviderInfo("MySql", new[] { "mysql", "sql" }, Script)
+{
+  // source: https://github.com/microsoft/monaco-editor/blob/main/website/src/website/data/home-samples/sample.mysql.txt
+  private const string Script = @"-- Sample
+CREATE TABLE shop (
+    article INT(4) UNSIGNED ZEROFILL DEFAULT '0000' NOT NULL,
+    dealer  CHAR(20)                 DEFAULT ''     NOT NULL,
+    price   DOUBLE(16,2)             DEFAULT '0.00' NOT NULL,
+    PRIMARY KEY(article, dealer));
+INSERT INTO shop VALUES
+    (1,'A',3.45),(1,'B',3.99),(2,'A',10.99),(3,'B',1.45),
+    (3,'C',1.69),(3,'D',1.25),(4,'D',19.95);
+";
+}

--- a/src/QueryPressure.MySql.App/MySqlProviderInfo.cs
+++ b/src/QueryPressure.MySql.App/MySqlProviderInfo.cs
@@ -6,7 +6,8 @@ public record MySqlProviderInfo()
   : ProviderInfo("MySql", new[] { "mysql", "sql" }, Script)
 {
   // source: https://github.com/microsoft/monaco-editor/blob/main/website/src/website/data/home-samples/sample.mysql.txt
-  private const string Script = @"-- Sample
+  private const string Script = """
+-- Sample
 CREATE TABLE shop (
     article INT(4) UNSIGNED ZEROFILL DEFAULT '0000' NOT NULL,
     dealer  CHAR(20)                 DEFAULT ''     NOT NULL,
@@ -15,5 +16,5 @@ CREATE TABLE shop (
 INSERT INTO shop VALUES
     (1,'A',3.45),(1,'B',3.99),(2,'A',10.99),(3,'B',1.45),
     (3,'C',1.69),(3,'D',1.25),(4,'D',19.95);
-";
+""";
 }

--- a/src/QueryPressure.MySql.App/MySqlProviderInfo.cs
+++ b/src/QueryPressure.MySql.App/MySqlProviderInfo.cs
@@ -2,7 +2,7 @@ using QueryPressure.Core;
 
 namespace QueryPressure.MySql.App;
 
-public record MySqlProviderInfo() 
+public record MySqlProviderInfo()
   : ProviderInfo("MySql", new[] { "mysql", "sql" }, Script)
 {
   // source: https://github.com/microsoft/monaco-editor/blob/main/website/src/website/data/home-samples/sample.mysql.txt

--- a/src/QueryPressure.Postgres.App/PostgresAppModule.cs
+++ b/src/QueryPressure.Postgres.App/PostgresAppModule.cs
@@ -10,7 +10,8 @@ public class PostgresAppModule : Module
     builder.RegisterType<PostgresConnectionProviderCreator>()
       .AsImplementedInterfaces();
 
-    builder.RegisterInstance(new PostgresProviderInfo())
-      .As<IProviderInfo>();
+    builder.RegisterType<PostgresProviderInfo>()
+      .As<IProviderInfo>()
+      .SingleInstance();
   }
 }

--- a/src/QueryPressure.Postgres.App/PostgresAppModule.cs
+++ b/src/QueryPressure.Postgres.App/PostgresAppModule.cs
@@ -1,5 +1,4 @@
 using Autofac;
-using QueryPressure.Core;
 using QueryPressure.Core.Interfaces;
 
 namespace QueryPressure.Postgres.App;
@@ -11,7 +10,7 @@ public class PostgresAppModule : Module
     builder.RegisterType<PostgresConnectionProviderCreator>()
       .AsImplementedInterfaces();
 
-    builder.RegisterInstance(new ProviderInfo("Postgres"))
+    builder.RegisterInstance(new PostgresProviderInfo())
       .As<IProviderInfo>();
   }
 }

--- a/src/QueryPressure.Postgres.App/PostgresProviderInfo.cs
+++ b/src/QueryPressure.Postgres.App/PostgresProviderInfo.cs
@@ -1,0 +1,32 @@
+using QueryPressure.Core;
+
+namespace QueryPressure.Postgres.App;
+
+public record PostgresProviderInfo() 
+  : ProviderInfo("Postgres", new[] { "pgsql", "sql" }, Script)
+{
+  private const string Script = @"-- Sample
+ SELECT
+    t.relname AS table_name,
+    a.attname AS column_name,
+    CASE
+      WHEN a.attnotnull THEN 'NOT NULL'
+      ELSE ''
+    END AS constraints,
+    i.relname AS index_name
+  FROM
+    pg_class t
+  JOIN
+    pg_attribute a ON t.oid = a.attrelid
+  LEFT JOIN
+    pg_index ix ON t.oid = ix.indrelid AND a.attnum = ANY(ix.indkey)
+  LEFT JOIN
+    pg_class i ON ix.indexrelid = i.oid
+  WHERE
+    t.relkind = 'r'  -- Only regular tables
+    AND t.relname NOT LIKE 'pg_%'  -- Exclude system tables
+    AND t.relname NOT LIKE 'sql_%'  -- Exclude SQL-standard tables
+  ORDER BY
+    t.relname, a.attnum;
+";
+}

--- a/src/QueryPressure.Postgres.App/PostgresProviderInfo.cs
+++ b/src/QueryPressure.Postgres.App/PostgresProviderInfo.cs
@@ -2,7 +2,7 @@ using QueryPressure.Core;
 
 namespace QueryPressure.Postgres.App;
 
-public record PostgresProviderInfo() 
+public record PostgresProviderInfo()
   : ProviderInfo("Postgres", new[] { "pgsql", "sql" }, Script)
 {
   private const string Script = @"-- Sample

--- a/src/QueryPressure.Postgres.App/PostgresProviderInfo.cs
+++ b/src/QueryPressure.Postgres.App/PostgresProviderInfo.cs
@@ -5,7 +5,8 @@ namespace QueryPressure.Postgres.App;
 public record PostgresProviderInfo()
   : ProviderInfo("Postgres", new[] { "pgsql", "sql" }, Script)
 {
-  private const string Script = @"-- Sample
+  private const string Script = """
+-- Sample
  SELECT
     t.relname AS table_name,
     a.attname AS column_name,
@@ -28,5 +29,5 @@ public record PostgresProviderInfo()
     AND t.relname NOT LIKE 'sql_%'  -- Exclude SQL-standard tables
   ORDER BY
     t.relname, a.attnum;
-";
+""";
 }

--- a/src/QueryPressure.Redis.App/RedisAppModule.cs
+++ b/src/QueryPressure.Redis.App/RedisAppModule.cs
@@ -10,7 +10,8 @@ public sealed class RedisAppModule : Module
     builder.RegisterType<RedisConnectionProviderCreator>()
       .AsImplementedInterfaces();
 
-    builder.RegisterInstance(new RedisProviderInfo())
-      .As<IProviderInfo>();
+    builder.RegisterType<RedisProviderInfo>()
+      .As<IProviderInfo>()
+      .SingleInstance();
   }
 }

--- a/src/QueryPressure.Redis.App/RedisAppModule.cs
+++ b/src/QueryPressure.Redis.App/RedisAppModule.cs
@@ -1,5 +1,4 @@
 using Autofac;
-using QueryPressure.Core;
 using QueryPressure.Core.Interfaces;
 
 namespace QueryPressure.Redis.App;
@@ -11,7 +10,7 @@ public sealed class RedisAppModule : Module
     builder.RegisterType<RedisConnectionProviderCreator>()
       .AsImplementedInterfaces();
 
-    builder.RegisterInstance(new ProviderInfo("Redis"))
+    builder.RegisterInstance(new RedisProviderInfo())
       .As<IProviderInfo>();
   }
 }

--- a/src/QueryPressure.Redis.App/RedisProviderInfo.cs
+++ b/src/QueryPressure.Redis.App/RedisProviderInfo.cs
@@ -3,7 +3,7 @@ using QueryPressure.Core;
 namespace QueryPressure.Redis.App;
 
 public record RedisProviderInfo()
-  : ProviderInfo("Redis", new [] { "redis", "lua" }, Script)
+  : ProviderInfo("Redis", new[] { "redis", "lua" }, Script)
 {
   // source: https://github.com/microsoft/monaco-editor/blob/main/website/src/website/data/home-samples/sample.redis.txt
   private const string Script = """

--- a/src/QueryPressure.Redis.App/RedisProviderInfo.cs
+++ b/src/QueryPressure.Redis.App/RedisProviderInfo.cs
@@ -1,0 +1,15 @@
+using QueryPressure.Core;
+
+namespace QueryPressure.Redis.App;
+
+public record RedisProviderInfo()
+  : ProviderInfo("Redis", new [] { "redis", "lua" }, Script)
+{
+  // source: https://github.com/microsoft/monaco-editor/blob/main/website/src/website/data/home-samples/sample.redis.txt
+  private const string Script = """
+EXISTS mykey
+APPEND mykey "Hello"
+APPEND mykey " World"
+GET mykey
+""";
+}

--- a/src/QueryPressure.SqlServer.App/SqlServerAppModule.cs
+++ b/src/QueryPressure.SqlServer.App/SqlServerAppModule.cs
@@ -1,5 +1,4 @@
 using Autofac;
-using QueryPressure.Core;
 using QueryPressure.Core.Interfaces;
 
 namespace QueryPressure.SqlServer.App
@@ -11,7 +10,7 @@ namespace QueryPressure.SqlServer.App
       builder.RegisterType<SqlServerConnectionProviderCreator>()
         .AsImplementedInterfaces();
 
-      builder.RegisterInstance(new ProviderInfo("SqlServer"))
+      builder.RegisterInstance(new SqlServerProviderInfo())
         .As<IProviderInfo>();
     }
   }

--- a/src/QueryPressure.SqlServer.App/SqlServerAppModule.cs
+++ b/src/QueryPressure.SqlServer.App/SqlServerAppModule.cs
@@ -1,17 +1,17 @@
 using Autofac;
 using QueryPressure.Core.Interfaces;
 
-namespace QueryPressure.SqlServer.App
-{
-  public class SqlServerAppModule : Module
-  {
-    protected override void Load(ContainerBuilder builder)
-    {
-      builder.RegisterType<SqlServerConnectionProviderCreator>()
-        .AsImplementedInterfaces();
+namespace QueryPressure.SqlServer.App;
 
-      builder.RegisterInstance(new SqlServerProviderInfo())
-        .As<IProviderInfo>();
-    }
+public class SqlServerAppModule : Module
+{
+  protected override void Load(ContainerBuilder builder)
+  {
+    builder.RegisterType<SqlServerConnectionProviderCreator>()
+      .AsImplementedInterfaces();
+
+    builder.RegisterType<SqlServerProviderInfo>()
+      .As<IProviderInfo>()
+      .SingleInstance();
   }
 }

--- a/src/QueryPressure.SqlServer.App/SqlServerProviderInfo.cs
+++ b/src/QueryPressure.SqlServer.App/SqlServerProviderInfo.cs
@@ -1,0 +1,63 @@
+using QueryPressure.Core;
+
+namespace QueryPressure.SqlServer.App;
+
+public record SqlServerProviderInfo()
+  : ProviderInfo("SqlServer", new[] { "tsql", "sql" }, Script)
+{
+  // source: https://github.com/microsoft/monaco-editor/blob/main/website/src/website/data/home-samples/sample.sql.txt
+  private const string Script = @"-- Sample
+CREATE TABLE dbo.EmployeePhoto
+(
+    EmployeeId INT NOT NULL PRIMARY KEY,
+    Photo VARBINARY(MAX) FILESTREAM NULL,
+    MyRowGuidColumn UNIQUEIDENTIFIER NOT NULL ROWGUIDCOL
+                    UNIQUE DEFAULT NEWID()
+);
+
+GO
+
+/*
+text_of_comment
+/* nested comment */
+*/
+
+-- line comment
+
+CREATE NONCLUSTERED INDEX IX_WorkOrder_ProductID
+    ON Production.WorkOrder(ProductID)
+    WITH (FILLFACTOR = 80,
+        PAD_INDEX = ON,
+        DROP_EXISTING = ON);
+GO
+
+WHILE (SELECT AVG(ListPrice) FROM Production.Product) < $300
+BEGIN
+   UPDATE Production.Product
+      SET ListPrice = ListPrice * 2
+   SELECT MAX(ListPrice) FROM Production.Product
+   IF (SELECT MAX(ListPrice) FROM Production.Product) > $500
+      BREAK
+   ELSE
+      CONTINUE
+END
+PRINT 'Too much for the market to bear';
+
+MERGE INTO Sales.SalesReason AS [Target]
+USING (VALUES ('Recommendation','Other'), ('Review', 'Marketing'), ('Internet', 'Promotion'))
+       AS [Source] ([NewName], NewReasonType)
+ON [Target].[Name] = [Source].[NewName]
+WHEN MATCHED
+THEN UPDATE SET ReasonType = [Source].NewReasonType
+WHEN NOT MATCHED BY TARGET
+THEN INSERT ([Name], ReasonType) VALUES ([NewName], NewReasonType)
+OUTPUT $action INTO @SummaryOfChanges;
+
+SELECT ProductID, OrderQty, SUM(LineTotal) AS Total
+FROM Sales.SalesOrderDetail
+WHERE UnitPrice < $5.00
+GROUP BY ProductID, OrderQty
+ORDER BY ProductID, OrderQty
+OPTION (HASH GROUP, FAST 10);
+";
+}

--- a/src/QueryPressure.SqlServer.App/SqlServerProviderInfo.cs
+++ b/src/QueryPressure.SqlServer.App/SqlServerProviderInfo.cs
@@ -6,7 +6,8 @@ public record SqlServerProviderInfo()
   : ProviderInfo("SqlServer", new[] { "tsql", "sql" }, Script)
 {
   // source: https://github.com/microsoft/monaco-editor/blob/main/website/src/website/data/home-samples/sample.sql.txt
-  private const string Script = @"-- Sample
+  private const string Script = """
+-- Sample
 CREATE TABLE dbo.EmployeePhoto
 (
     EmployeeId INT NOT NULL PRIMARY KEY,
@@ -59,5 +60,5 @@ WHERE UnitPrice < $5.00
 GROUP BY ProductID, OrderQty
 ORDER BY ProductID, OrderQty
 OPTION (HASH GROUP, FAST 10);
-";
+""";
 }

--- a/src/QueryPressure.UI/Program.cs
+++ b/src/QueryPressure.UI/Program.cs
@@ -32,7 +32,7 @@ app.OpenBrowserWhenReady();
 
 app.MapHub<DashboardHub>("/ws/dashboard");
 
-app.MapGet("/api/providers", (IProviderInfo[] providers) => providers.Select(x => x.Name));
+app.MapGet("/api/providers", (IProviderInfo[] providers) => providers);
 
 app.MapPost("/api/connection/test", async (ConnectionRequest request, ProviderManager manager) =>
   await manager.GetProvider(request.Provider).TestConnectionAsync(request.ConnectionString));


### PR DESCRIPTION
- added highlighting of selected provider  
- added initial script for providers
 
 Important notes: 
 - initial script applied if the editor has no content or the page reloaded, it was made due to avoid accidental deletions of an existing script 
 - provider is able to have a few syntax support (e.g. `pgsql` and `sql`). Only first founded syntax will be applied on front-end side 
 - I didn't find full syntax support for `MongoDB`, can but some issues with that provider
 